### PR TITLE
Reference AWS_REGION from environment variables or ~/.aws/credentials as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ cognito-backup backup-all-users <options>  Backup all users in all user pools fo
 ## Examples
 ```
 cognito-backup backup-users eu-west-1_1_12345
-cognito-backup backup-users eu-west-1_1_12345 --region eu-west-1 --file mypool.json
-cognito-backup backup-all-users eu-west-1_1_12345 --region eu-west-1 --dir output
+cognito-backup backup-users eu-west-1_1_12345 --file mypool.json
+cognito-backup backup-all-users eu-west-1_1_12345 --dir output
 
 # Nominate region if not set in environment variable or ~/.aws/credentials
 AWS_region=ap-southeast-2 cognito-backup backup-all-users ap-southeast-2_123456

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ cognito-backup backup-all-users <options>  Backup all users in all user pools fo
 cognito-backup backup-users eu-west-1_1_12345
 cognito-backup backup-users eu-west-1_1_12345 --region eu-west-1 --file mypool.json
 cognito-backup backup-all-users eu-west-1_1_12345 --region eu-west-1 --dir output
+
+# Nominate region if not set in environment variable or ~/.aws/credentials
+AWS_region=ap-southeast-2 cognito-backup backup-all-users ap-southeast-2_123456
 ```
 
 ## TODO

--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 'use strict';
 
 const meow = require('meow');
@@ -27,87 +28,93 @@ const cli = meow(`
 `);
 
 const methods = {
-  'backup-users': backupUsersCli,
-  'backup-all-users': backupAllUsersCli,
+    'backup-users': backupUsersCli,
+    'backup-all-users': backupAllUsersCli,
 };
 
 const method = methods[cli.input[0]] || cli.showHelp();
 
 bluebird.resolve(method.call(undefined, cli))
-  .catch(err => {
-    console.error(err.stack);
-    process.exit(1);
-  });
+    .catch(err => {
+        console.error(err.stack);
+        process.exit(1);
+    });
 
 
 function backupUsersCli(cli) {
-  const userPoolId = cli.input[1];
-  const file = cli.flags.file;
-  const file2 = file || sanitizeFilename(getFilename(userPoolId));
+    const userPoolId = cli.input[1];
+    const file = cli.flags.file;
+    const file2 = file || sanitizeFilename(getFilename(userPoolId));
 
-  if (!userPoolId) {
-    console.error('user-pool-id is required');
-    cli.showHelp();
-  }
+    if (!userPoolId) {
+        console.error('user-pool-id is required');
+        cli.showHelp();
+    }
 
-  const cognitoIsp = new AWS.CognitoIdentityServiceProvider();
+    const cognitoIsp = new AWS.CognitoIdentityServiceProvider();
 
-  return backupUsers(cognitoIsp, userPoolId, file2);
+    return backupUsers(cognitoIsp, userPoolId, file2);
 }
 
 function backupAllUsersCli(cli) {
-  const dir = cli.flags.dir || '.';
+    const dir = cli.flags.dir || '.';
 
-  const cognitoIsp = new AWS.CognitoIdentityServiceProvider();
+    const cognitoIsp = new AWS.CognitoIdentityServiceProvider();
 
-  return mkdirp(dir)
-  .then(() => bluebird.mapSeries(listUserPools(), userPoolId => {
-    const file = path.join(dir, getFilename(userPoolId));
-    console.error(`Exporting ${userPoolId} to ${file}`);
-    return backupUsers(cognitoIsp, userPoolId, file);
-  }));
+    return mkdirp(dir)
+        .then(() => bluebird.mapSeries(listUserPools(), userPoolId => {
+            const file = path.join(dir, getFilename(userPoolId));
+            console.error(`Exporting ${userPoolId} to ${file}`);
+            return backupUsers(cognitoIsp, userPoolId, file);
+        }));
 }
 
 function getFilename(userPoolId) {
-  return `${userPoolId}.json`;
+    return `${userPoolId}.json`;
 }
 
 function listUserPools() {
-  const cognitoIsp = new AWS.CognitoIdentityServiceProvider();
+    const cognitoIsp = new AWS.CognitoIdentityServiceProvider();
 
-  return cognitoIsp.listUserPools({ MaxResults: 60 }).promise()
-    .then(data => {
-      assert(!data.NextToken, 'More than 60 user pools is not yet supported');
-      const userPools = data.UserPools;
-      debug({ userPools });
-      return userPools.map(p => p.Id);
-    });
+    return cognitoIsp.listUserPools({
+            MaxResults: 60
+        }).promise()
+        .then(data => {
+            assert(!data.NextToken, 'More than 60 user pools is not yet supported');
+            const userPools = data.UserPools;
+            debug({
+                userPools
+            });
+            return userPools.map(p => p.Id);
+        });
 }
 
 function backupUsers(cognitoIsp, userPoolId, file) {
-  const writeStream = fs.createWriteStream(file);
-  const stringify = JSONStream.stringify();
+    const writeStream = fs.createWriteStream(file);
+    const stringify = JSONStream.stringify();
 
-  stringify.pipe(writeStream);
+    stringify.pipe(writeStream);
 
-  const params = { UserPoolId: userPoolId };
-  const page = () => {
-    debug(`Fetching users - page: ${params.PaginationToken || 'first'}`);
-    return bluebird.resolve(cognitoIsp.listUsers(params).promise())
-      .then(data => {
-        data.Users.forEach(item => stringify.write(item));
+    const params = {
+        UserPoolId: userPoolId
+    };
+    const page = () => {
+        debug(`Fetching users - page: ${params.PaginationToken || 'first'}`);
+        return bluebird.resolve(cognitoIsp.listUsers(params).promise())
+            .then(data => {
+                data.Users.forEach(item => stringify.write(item));
 
-        if (data.PaginationToken !== undefined) {
-          params.PaginationToken = data.PaginationToken;
-          return page();
-        }
-      });
-  }
+                if (data.PaginationToken !== undefined) {
+                    params.PaginationToken = data.PaginationToken;
+                    return page();
+                }
+            });
+    }
 
-  return page()
-    .finally(() => {
-      stringify.end();
-      return streamToPromise(stringify);
-    })
-    .finally(() => writeStream.end());
+    return page()
+        .finally(() => {
+            stringify.end();
+            return streamToPromise(stringify);
+        })
+        .finally(() => writeStream.end());
 }


### PR DESCRIPTION
update: 

1) since we reference `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from environment variables or `~/.aws/credentials`, it should be same for `AWS_REGION`

2) Cognito user pool id has the region in id name already, but I am not sure if aws will change the format later. So currently don't apply this logic on the codes. 

3) js-beautify the javascript `cli.js`