### PR TITLE
feat: Add configurable maxAttempts flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -61,7 +61,12 @@ const cli = meow(
   },
 );
 
-const { region, concurrency = 1, verbose = false, maxAttempts = 5 } = cli.flags;
+const {
+  region,
+  concurrency = 1,
+  verbose = false,
+  maxAttempts = 5,
+} = cli.flags;
 
 const config = {
   region,

--- a/cli.js
+++ b/cli.js
@@ -96,8 +96,6 @@ async function backupUsers(userPoolId, file) {
   const params = { UserPoolId: userPoolId };
 
   async function getUserGroupNames(user) {
-    // This is where our backup jobs are failing (consistently) but there's
-    // not much you can do to make this less request-heavy AFAIK
     const data = await cognitoIsp.send(new AdminListGroupsForUserCommand({
       UserPoolId: userPoolId,
       Username: user.Username,


### PR DESCRIPTION
We're having issues listing groups for users when backing up user pools with this tool (403 TooManyRequests) so wanted to add this option for debugging purposes.